### PR TITLE
Define Thumbnail Candidates

### DIFF
--- a/lib/pageflow/before_after/page_type.rb
+++ b/lib/pageflow/before_after/page_type.rb
@@ -2,6 +2,13 @@ module Pageflow
   module BeforeAfter
     class PageType < Pageflow::PageType
       name 'before_after'
+
+      def thumbnail_candidates
+        [
+          {attribute: 'thumbnail_image_id', file_collection: 'image_files'},
+          {attribute: 'after_image_id', file_collection: 'image_files'}
+        ]
+      end
     end
   end
 end


### PR DESCRIPTION
Starting with version 0.5, pageflow supports supplying custom
thumbnails for new page types.
