### PR TITLE
Make Control Bar Text Configurable

### DIFF
--- a/app/assets/javascripts/pageflow/before_after.js
+++ b/app/assets/javascripts/pageflow/before_after.js
@@ -49,6 +49,10 @@ pageflow.pageType.register('before_after', _.extend({
     pageElement.find('h2 .title').text(configuration.get('title') || '');
     pageElement.find('h2 .subtitle').text(configuration.get('subtitle') || '');
     pageElement.find('p').html(configuration.get('text') || '');
+    pageElement.find('.control_bar_text').text(configuration.get('control_bar_text') ||
+                                               I18n.t('pageflow.before_after.page.start', {
+                                                 locale: pageflow.entry.configuration.get('locale')
+                                               }));
 
     this.updateInfoBox(pageElement, configuration);
     this.updateCommonPageCssClasses(pageElement, configuration);

--- a/app/assets/javascripts/pageflow/before_after/editor.js
+++ b/app/assets/javascripts/pageflow/before_after/editor.js
@@ -8,6 +8,11 @@ pageflow.ConfigurationEditorView.register('before_after', {
     this.tab('general', function() {
       this.group('general');
 
+      this.input('control_bar_text', pageflow.TextInputView, {
+        placeholder: I18n.t('pageflow.before_after.page.start', {
+          locale: pageflow.entry.configuration.get('locale')
+        })
+      });
       this.input('additional_title', pageflow.TextInputView);
       this.input('additional_description', pageflow.TextAreaInputView, {size: 'short'});
     });

--- a/app/views/pageflow/before_after/page.html.erb
+++ b/app/views/pageflow/before_after/page.html.erb
@@ -31,7 +31,7 @@
           <a class="vjs-play-control vjs-play vjs-control" tabindex="4" title="<%= t('.start_title') %>"><span></span></a>
         </div>
         <div class="control_bar_text">
-          <%= t('.start') %>
+          <%= configuration['control_bar_text'].presence || t('.start') %>
         </div>
       </div>
     </div>

--- a/config/locales/new/control_bar_text.yml
+++ b/config/locales/new/control_bar_text.yml
@@ -1,0 +1,11 @@
+de:
+  activerecord:
+    attributes:
+      pageflow/page:
+        control_bar_text: Start-Button Beschriftung
+
+en:
+  activerecord:
+    attributes:
+      pageflow/page:
+        control_bar_text: Start-button caption

--- a/lib/pageflow/before_after/engine.rb
+++ b/lib/pageflow/before_after/engine.rb
@@ -4,6 +4,7 @@ module Pageflow
       isolate_namespace Pageflow::BeforeAfter
 
       config.autoload_paths << File.join(config.root, 'lib')
+      config.i18n.load_path += Dir[config.root.join('config', 'locales', '**', '*.yml').to_s]
     end
   end
 end


### PR DESCRIPTION
Allow to display a more content specific text next to the play button
that opens the before/after view.