### PR TITLE
Add css class to background for slim controls shadow

### DIFF
--- a/app/views/pageflow/before_after/page.html.erb
+++ b/app/views/pageflow/before_after/page.html.erb
@@ -6,7 +6,7 @@
     </div>
   </div>
 
-  <div class="backgroundArea">
+  <div class="backgroundArea page_background page_background-for_page_with_player_controls">
     <div class="videoWrapper">
       <div class="before_after_container">
         <div class="before_after">


### PR DESCRIPTION
The page background of pages with player controls now requires a
special css class.