### PR TITLE
Only refresh widget on resize if initialized

### DIFF
--- a/app/assets/javascripts/pageflow/before_after.js
+++ b/app/assets/javascripts/pageflow/before_after.js
@@ -32,7 +32,12 @@ pageflow.pageType.register('before_after', _.extend({
   },
 
   resize: function(pageElement, configuration) {
-    pageElement.find(".before_after").before_after("refresh");
+    var beforeAfterElement = pageElement.find('.before_after');
+
+    if (beforeAfterElement.before_after('instance')) {
+      beforeAfterElement.before_after('refresh');
+    }
+
     pageElement.find('.scroller').scroller("refresh");
   },
 


### PR DESCRIPTION
When the cookie hint is enabled, `resize` gets called before
`activating`. Trying to call `refresh` on the not yet initialized
`before_after` widget causes an exception and breaks the entry.

REDMINE-16729